### PR TITLE
style selector icons now responsive

### DIFF
--- a/src/styles/overview.scss
+++ b/src/styles/overview.scss
@@ -3,7 +3,6 @@
 //////////////
 // OVERVIEW //
 //////////////
-///
 .overview {
   height: 55rem;
   display: flex;
@@ -168,18 +167,18 @@
 
       .style-selector {
         height: 33%;
-        width: 100%;
-        max-width: 21rem;
+        width: 22vw;
         border: 1px solid pink;
         display: flex;
         flex-wrap: wrap;
 
         .circle {
+          $radius: 4vw;
           border: 1px solid black;
           border-radius: 50%;
-          width: 4rem;
-          height: 4rem;
-          margin-right: 1rem;
+          width: $radius;
+          height: $radius;
+          margin-right: 1vw;
           cursor: pointer;
         }
 


### PR DESCRIPTION
Made the style selector icons and the style selector box responsive by defining their width with vw units. It's pretty nifty! Now no matter how large or small you make the viewport they'll stay 4 to a row.